### PR TITLE
Falling back to config file defaults in using executor class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Fixed
+
+- Falling back to config file defaults when using executor via instantiation of executor class
+
 ## [0.11.0] - 2022-10-03
 
 

--- a/covalent_awslambda_plugin/awslambda.py
+++ b/covalent_awslambda_plugin/awslambda.py
@@ -34,9 +34,10 @@ import boto3
 import botocore.exceptions
 import cloudpickle as pickle
 from boto3.session import Session
-from covalent._shared_files import logger
 from covalent._shared_files.config import get_config
 from covalent_aws_plugins import AWSExecutor
+
+from covalent._shared_files import logger
 
 from .scripts import PYTHON_EXEC_SCRIPT
 
@@ -151,11 +152,11 @@ class AWSLambdaExecutor(AWSExecutor):
 
     def __init__(
         self,
-        credentials_file: str,
-        profile: str,
-        region: str,
         s3_bucket_name: str,
         execution_role: str,
+        credentials_file: str = None,
+        profile: str = None,
+        region: str = None,
         poll_freq: int = None,
         timeout: int = None,
         memory_size: int = None,
@@ -164,11 +165,12 @@ class AWSLambdaExecutor(AWSExecutor):
 
         # AWSExecutor parameters
         required_attrs = {
-            "credentials_file": credentials_file,
-            "profile": profile,
-            "region": region,
-            "s3_bucket_name": s3_bucket_name,
-            "execution_role": execution_role,
+            "credentials_file": credentials_file
+            or get_config("executors.awslambda.credentials_file"),
+            "profile": profile or get_config("executors.awslambda.profile"),
+            "region": region or get_config("executors.awslambda.region"),
+            "s3_bucket_name": s3_bucket_name or get_config("executors.awslambda.s3_bucket_name"),
+            "execution_role": execution_role or get_config("executors.awslambda.execution_role"),
         }
 
         super().__init__(**required_attrs)

--- a/covalent_awslambda_plugin/awslambda.py
+++ b/covalent_awslambda_plugin/awslambda.py
@@ -34,10 +34,9 @@ import boto3
 import botocore.exceptions
 import cloudpickle as pickle
 from boto3.session import Session
+from covalent._shared_files import logger
 from covalent._shared_files.config import get_config
 from covalent_aws_plugins import AWSExecutor
-
-from covalent._shared_files import logger
 
 from .scripts import PYTHON_EXEC_SCRIPT
 


### PR DESCRIPTION
Falling back to config file defaults when using executor via instantiation of executor class

- [ ] I have added the tests to cover my changes.
- [x] I have updated the documentation and CHANGELOG accordingly.
- [x] I have read the CONTRIBUTING document.
